### PR TITLE
Add pre-partitioned hook to model and adapter

### DIFF
--- a/cstar/orchestration/adapter.py
+++ b/cstar/orchestration/adapter.py
@@ -116,6 +116,12 @@ class GridAdapter(ModelAdapter[models.RomsMarblBlueprint, ROMSModelGrid]):
             ),
             start_date=self.model.valid_start_date,
             end_date=self.model.valid_end_date,
+            source_np_xi=self.model.partitioning.n_procs_x
+            if self.model.grid.data.partitioned
+            else None,
+            source_np_eta=self.model.partitioning.n_procs_y
+            if self.model.grid.data.partitioned
+            else None,
         )
 
 
@@ -137,6 +143,12 @@ class InitialConditionAdapter(
             ),
             start_date=self.model.valid_start_date,
             end_date=self.model.valid_end_date,
+            source_np_xi=self.model.partitioning.n_procs_x
+            if self.model.initial_conditions.data.partitioned
+            else None,
+            source_np_eta=self.model.partitioning.n_procs_y
+            if self.model.initial_conditions.data.partitioned
+            else None,
         )
 
 
@@ -156,6 +168,12 @@ class TidalForcingAdapter(ModelAdapter[models.RomsMarblBlueprint, ROMSTidalForci
             ),
             start_date=self.model.valid_start_date,
             end_date=self.model.valid_end_date,
+            source_np_xi=self.model.partitioning.n_procs_x
+            if self.model.forcing.tidal.data.partitioned
+            else None,
+            source_np_eta=self.model.partitioning.n_procs_y
+            if self.model.forcing.tidal.data.partitioned
+            else None,
         )
 
 
@@ -176,6 +194,12 @@ class RiverForcingAdapter(ModelAdapter[models.RomsMarblBlueprint, ROMSRiverForci
             ),
             start_date=self.model.valid_start_date,
             end_date=self.model.valid_end_date,
+            source_np_xi=self.model.partitioning.n_procs_x
+            if self.model.forcing.river.data.partitioned
+            else None,
+            source_np_eta=self.model.partitioning.n_procs_y
+            if self.model.forcing.river.data.partitioned
+            else None,
         )
 
 
@@ -192,6 +216,12 @@ class BoundaryForcingAdapter(
                 file_hash=(f.hash if isinstance(f, models.VersionedResource) else None),
                 start_date=self.model.valid_start_date,
                 end_date=self.model.valid_end_date,
+                source_np_xi=self.model.partitioning.n_procs_x
+                if f.partitioned
+                else None,
+                source_np_eta=self.model.partitioning.n_procs_y
+                if f.partitioned
+                else None,
             )
             for f in self.model.forcing.boundary.data
         ]
@@ -210,6 +240,12 @@ class SurfaceForcingAdapter(
                 file_hash=(f.hash if isinstance(f, models.VersionedResource) else None),
                 start_date=self.model.valid_start_date,
                 end_date=self.model.valid_end_date,
+                source_np_xi=self.model.partitioning.n_procs_x
+                if f.partitioned
+                else None,
+                source_np_eta=self.model.partitioning.n_procs_y
+                if f.partitioned
+                else None,
             )
             for f in self.model.forcing.surface.data
         ]
@@ -244,6 +280,12 @@ class ForcingCorrectionAdapter(
                 file_hash=(f.hash if isinstance(f, models.VersionedResource) else None),
                 start_date=self.model.valid_start_date,
                 end_date=self.model.valid_end_date,
+                source_np_xi=self.model.partitioning.n_procs_x
+                if f.partitioned
+                else None,
+                source_np_eta=self.model.partitioning.n_procs_y
+                if f.partitioned
+                else None,
             )
             for f in self.model.forcing.corrections.data
         ]

--- a/cstar/orchestration/models.py
+++ b/cstar/orchestration/models.py
@@ -48,6 +48,8 @@ class Resource(ConfiguredBaseModel):
     location: FilePath | HttpUrl
     """Location of the file to retrieve."""
 
+    partitioned: bool = Field(default=False, init=False)
+
 
 class VersionedResource(Resource):
     hash: RequiredString

--- a/cstar/tests/unit_tests/conftest.py
+++ b/cstar/tests/unit_tests/conftest.py
@@ -504,6 +504,7 @@ def fake_romssimulation(
                 location="http://my.files/sw_corr.nc", file_hash="890"
             ),
         ],
+        cdr_forcing=ROMSCdrForcing(location="http://my.files/cdr.nc", file_hash="542"),
     )
 
     yield sim  # Ensures pytest can handle resource cleanup if needed


### PR DESCRIPTION
Ties in some functionality that we added after the initial blueprint design. Now you can specify that a given input dataset is pre-partitioned, and it will pass the partitioning info for the blueprint into the dataset adapter.

Also fixes a unit test from the CDR stuff that was failing. I swear it worked before, but  maybe something got dropped with some of the squash-rebase stuff 🤷 .